### PR TITLE
Update to enable syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,13 +44,16 @@ paginate_path: /blog/page:num/
 
 # Build settings
 markdown: kramdown
-highlighter: pygments
-
-collections:
-  datasets:
-    output: true
-    permalink: /datasets/:path/
-    sort_by: order_number
+highlighter: rouge
+kramdown:
+    input: GFM
+    syntax_highlighter: rouge
+    
+# collections:
+#   datasets:
+#     output: true
+#     permalink: /datasets/:path/
+#     sort_by: order_number
       
 # Plug-ins
 plugins:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
 	<title>{{ site.title }} {{ site.tagline }}</title>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/highlight.css" />
 	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css" />
 	<!--[if lte IE 9]><link rel="stylesheet" href="assets/css/ie9.css" /><![endif]-->
 	<!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
 	<title>{{ site.title }} {{ site.tagline }}</title>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/custom.css" />
 	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/highlight.css" />
 	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css" />
 	<!--[if lte IE 9]><link rel="stylesheet" href="assets/css/ie9.css" /><![endif]-->

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,35 @@
+/*
+
+Additional items added manually here
+
+*/
+
+.blog-category {
+    font-size: 12px;
+    color: #2b93db;
+    background-color: #d9ecf9;
+    padding: 3px;
+
+    &:hover {
+        color: #1f77b4;
+        text-decoration: underline;
+    }
+}
+
+.blog-tag {
+    font-size: 12px;
+    color: #df5152;
+    background-color: #fbe8e8;
+    padding: 3px;
+
+    &:hover {
+        color: #d62728;
+        text-decoration: underline;
+    }
+}
+
+.post-meta {
+    color: #828282;
+    font-size: 0.875rem;
+    margin-bottom: 0px;
+}

--- a/assets/css/highlight.css
+++ b/assets/css/highlight.css
@@ -1,0 +1,71 @@
+/*
+Generated with
+$ pygmentize -S arduino -f html -a .highlight > assets/css/highlight.css
+*/
+
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; font-weight: bold;}
+.highlight .c { color: #95a5a6 } /* Comment */
+.highlight .err { color: #a61717 } /* Error */
+.highlight .k { color: #728E00 } /* Keyword */
+.highlight .n { color: #434f54 } /* Name */
+.highlight .o { color: #728E00 } /* Operator */
+.highlight .ch { color: #95a5a6 } /* Comment.Hashbang */
+.highlight .cm { color: #95a5a6 } /* Comment.Multiline */
+.highlight .cp { color: #728E00 } /* Comment.Preproc */
+.highlight .cpf { color: #95a5a6 } /* Comment.PreprocFile */
+.highlight .c1 { color: #95a5a6 } /* Comment.Single */
+.highlight .cs { color: #95a5a6 } /* Comment.Special */
+.highlight .kc { color: #00979D } /* Keyword.Constant */
+.highlight .kd { color: #728E00 } /* Keyword.Declaration */
+.highlight .kn { color: #728E00 } /* Keyword.Namespace */
+.highlight .kp { color: #00979D } /* Keyword.Pseudo */
+.highlight .kr { color: #00979D } /* Keyword.Reserved */
+.highlight .kt { color: #00979D } /* Keyword.Type */
+.highlight .m { color: #8A7B52 } /* Literal.Number */
+.highlight .s { color: #7F8C8D } /* Literal.String */
+.highlight .na { color: #434f54 } /* Name.Attribute */
+.highlight .nb { color: #728E00 } /* Name.Builtin */
+.highlight .nc { color: #434f54 } /* Name.Class */
+.highlight .no { color: #434f54 } /* Name.Constant */
+.highlight .nd { color: #434f54 } /* Name.Decorator */
+.highlight .ni { color: #434f54 } /* Name.Entity */
+.highlight .ne { color: #434f54 } /* Name.Exception */
+.highlight .nf { color: #D35400 } /* Name.Function */
+.highlight .nl { color: #434f54 } /* Name.Label */
+.highlight .nn { color: #434f54 } /* Name.Namespace */
+.highlight .nx { color: #728E00 } /* Name.Other */
+.highlight .py { color: #434f54 } /* Name.Property */
+.highlight .nt { color: #434f54 } /* Name.Tag */
+.highlight .nv { color: #434f54 } /* Name.Variable */
+.highlight .ow { color: #728E00 } /* Operator.Word */
+.highlight .mb { color: #8A7B52 } /* Literal.Number.Bin */
+.highlight .mf { color: #8A7B52 } /* Literal.Number.Float */
+.highlight .mh { color: #8A7B52 } /* Literal.Number.Hex */
+.highlight .mi { color: #8A7B52 } /* Literal.Number.Integer */
+.highlight .mo { color: #8A7B52 } /* Literal.Number.Oct */
+.highlight .sa { color: #7F8C8D } /* Literal.String.Affix */
+.highlight .sb { color: #7F8C8D } /* Literal.String.Backtick */
+.highlight .sc { color: #7F8C8D } /* Literal.String.Char */
+.highlight .dl { color: #7F8C8D } /* Literal.String.Delimiter */
+.highlight .sd { color: #7F8C8D } /* Literal.String.Doc */
+.highlight .s2 { color: #7F8C8D } /* Literal.String.Double */
+.highlight .se { color: #7F8C8D } /* Literal.String.Escape */
+.highlight .sh { color: #7F8C8D } /* Literal.String.Heredoc */
+.highlight .si { color: #7F8C8D } /* Literal.String.Interpol */
+.highlight .sx { color: #7F8C8D } /* Literal.String.Other */
+.highlight .sr { color: #7F8C8D } /* Literal.String.Regex */
+.highlight .s1 { color: #7F8C8D } /* Literal.String.Single */
+.highlight .ss { color: #7F8C8D } /* Literal.String.Symbol */
+.highlight .bp { color: #728E00 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #D35400 } /* Name.Function.Magic */
+.highlight .vc { color: #434f54 } /* Name.Variable.Class */
+.highlight .vg { color: #434f54 } /* Name.Variable.Global */
+.highlight .vi { color: #434f54 } /* Name.Variable.Instance */
+.highlight .vm { color: #434f54 } /* Name.Variable.Magic */
+.highlight .il { color: #8A7B52 } /* Literal.Number.Integer.Long */

--- a/assets/css/highlight.css
+++ b/assets/css/highlight.css
@@ -1,6 +1,13 @@
 /*
 Generated with
 $ pygmentize -S arduino -f html -a .highlight > assets/css/highlight.css
+
+With extra 
+
+    .highlight { background: #ffffff; font-weight: bold;}
+
+for better contrast
+
 */
 
 pre { line-height: 125%; }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -7,37 +7,6 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 */
 
-/* GBr */
-.blog-category {
-    font-size: 12px;
-    color: #2b93db;
-    background-color: #d9ecf9;
-    padding: 3px;
-
-    &:hover {
-        color: #1f77b4;
-        text-decoration: underline;
-    }
-}
-
-.blog-tag {
-    font-size: 12px;
-    color: #df5152;
-    background-color: #fbe8e8;
-    padding: 3px;
-
-    &:hover {
-        color: #d62728;
-        text-decoration: underline;
-    }
-}
-
-.post-meta {
-    color: #828282;
-    font-size: 0.875rem;
-    margin-bottom: 0px;
-}
-
 /* Reset */
 
 	html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -38,31 +38,6 @@
     margin-bottom: 0px;
 }
 
-/* Manual specification for syntax highlighting? */
-.highlight .c, .highlight .cs, .highlight .cm, .highlight .cp, .highlight .c1 { color: #666; font-style: italic; }
-
-.highlight .k, .highlight .kc, .highlight .kd, .highlight .kn, .highlight .kr, .highlight .kt, .highlight .kp { color: #00369f; }
-
-.highlight .na, .highlight .nb, .highlight .nc, .highlight .no, .highlight .nd, .highlight .ni, .highlight .ne, .highlight .nf, .highlight .nl, .highlight .nn, .highlight .nx { color: #333; }
-
-.highlight .mi, .highlight .il { color: #009f06; }
-
-.highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .s3, .highlight .sh, .highlight .si, .highlight .sx, .highlight .sr, .highlight .ss, .highlight .s1 { color: #FF3636; }
-
-.hljs-title, .hljs-id, .scss .hljs-preprocessor { color: #FF3636; font-weight: bold; }
-
-.highlight .k { font-weight: normal; }
-
-.highlight .nc, .highlight .no { color: #00369f; }
-
-.highlight .o { color: #00369f; font-weight: normal; }
-
-.highlight .nb { color: #009f06; }
-
-.highlight .sr { color: #009f06; }
-
-.highlight .ss { color: #B509AC; }
-
 /* Reset */
 
 	html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -38,6 +38,31 @@
     margin-bottom: 0px;
 }
 
+/* Manual specification for syntax highlighting? */
+.highlight .c, .highlight .cs, .highlight .cm, .highlight .cp, .highlight .c1 { color: #666; font-style: italic; }
+
+.highlight .k, .highlight .kc, .highlight .kd, .highlight .kn, .highlight .kr, .highlight .kt, .highlight .kp { color: #00369f; }
+
+.highlight .na, .highlight .nb, .highlight .nc, .highlight .no, .highlight .nd, .highlight .ni, .highlight .ne, .highlight .nf, .highlight .nl, .highlight .nn, .highlight .nx { color: #333; }
+
+.highlight .mi, .highlight .il { color: #009f06; }
+
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .s3, .highlight .sh, .highlight .si, .highlight .sx, .highlight .sr, .highlight .ss, .highlight .s1 { color: #FF3636; }
+
+.hljs-title, .hljs-id, .scss .hljs-preprocessor { color: #FF3636; font-weight: bold; }
+
+.highlight .k { font-weight: normal; }
+
+.highlight .nc, .highlight .no { color: #00369f; }
+
+.highlight .o { color: #00369f; font-weight: normal; }
+
+.highlight .nb { color: #009f06; }
+
+.highlight .sr { color: #009f06; }
+
+.highlight .ss { color: #B509AC; }
+
 /* Reset */
 
 	html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {


### PR DESCRIPTION
This quick fix should enable syntax highlighting in the `_posts` generated from notebooks, and probably elsewhere as well in Markdown blocks like 

    ```python
    test code
    ```

